### PR TITLE
Disable nginx access log

### DIFF
--- a/devices/gl-6416/files/etc/nginx/nginx.conf
+++ b/devices/gl-6416/files/etc/nginx/nginx.conf
@@ -23,6 +23,7 @@ http {
     #                  '"$http_user_agent" "$http_x_forwarded_for"';
 
     #access_log  logs/access.log  main;
+    access_log  off;
 
     sendfile        on;
     #tcp_nopush     on;

--- a/devices/gl-ar150/files/etc/nginx/nginx.conf
+++ b/devices/gl-ar150/files/etc/nginx/nginx.conf
@@ -23,6 +23,7 @@ http {
     #                  '"$http_user_agent" "$http_x_forwarded_for"';
 
     #access_log  logs/access.log  main;
+    access_log  off;
 
     sendfile        on;
     #tcp_nopush     on;

--- a/devices/gl-mt300a/files/etc/nginx/nginx.conf
+++ b/devices/gl-mt300a/files/etc/nginx/nginx.conf
@@ -23,6 +23,7 @@ http {
     #                  '"$http_user_agent" "$http_x_forwarded_for"';
 
     #access_log  logs/access.log  main;
+    access_log  off;
 
     sendfile        on;
     #tcp_nopush     on;


### PR DESCRIPTION
Disable access logs of nginx on the GL Inet devices, since they have limited writes available.

Fixes https://github.com/SIDN/spin/issues/4